### PR TITLE
Fix pipeline test

### DIFF
--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -42,13 +42,13 @@ class TestRecommendation(unittest.TestCase):
         # Set up the test database
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        Recommendation.init_db(app)
 
     @classmethod
     def tearDownClass(cls):
         """ These run once after Test suite """
 
     def setUp(self):
-        Recommendation.init_db(app)
         db.drop_all()  # clean up the last tests
         db.create_all()  # make our sqlalchemy tables
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -52,6 +52,7 @@ class TestRecommendationService(unittest.TestCase):
         # Set up the test database
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        init_db()
 
     @classmethod
     def tearDownClass(cls):
@@ -59,7 +60,6 @@ class TestRecommendationService(unittest.TestCase):
 
     def setUp(self):
         """ Runs before each test """
-        init_db()
         db.drop_all()  # clean up the last tests
         db.create_all()  # create new tables
         self.app = app.test_client()


### PR DESCRIPTION
In our code the initialization of database when testing is inside the `setUp(self)` function, so the db is initialized once for every test case, which may be the reason for `too many connections` error. (We are using free ElephantSQL account which allows only 5 concurrent connections.)
Now the init is changed to be inside `setUpClass(cls)`, which only run once before the test suite.
The Build/Test stage in the delivery pipeline should now pass.

The Deploy stage is also added. Now when we run Build/Test stage and if it succeeded, the app will automatically be deployed to the dev space.