### PR TITLE
refactor deleting a unique recommendation by id and rel_id

### DIFF
--- a/service/model.py
+++ b/service/model.py
@@ -153,6 +153,17 @@ class Recommendation(db.Model):
         return cls.query.filter(cls.id==by_id)
 
     @classmethod
+    def find_by_id_relid(cls, by_id, by_rel_id):
+        """ Find a unique recommendation by product_id and rel_product_id """
+        if not by_id or not isinstance(by_id, int):
+            raise TypeError("by_id is not of type int")
+        if not by_rel_id or not isinstance(by_rel_id, int):
+            raise TypeError("by_rel_id is not of type int")
+        
+        cls.logger.info("Processing lookup for id %s with rel id %s ...", by_id, by_rel_id)
+        return cls.query.filter(cls.id==by_id, cls.rel_id==by_rel_id)
+
+    @classmethod
     def find_by_id_status(cls, by_id: int, by_status=True):
         """ Find [status: active/inactive] recommendations of a [product: id] """
         if not by_id or not isinstance(by_id, int):

--- a/service/service.py
+++ b/service/service.py
@@ -461,6 +461,33 @@ def delete_all_by_id(product_id):
 
 
 ######################################################################
+# DELETE ALL RELEATIONSHIP OF A PRODUCT BY ID
+######################################################################
+@app.route('/recommendations/<int:product_id>/<int:rel_product_id>', methods=['DELETE'])
+def delete_by_id_relid(product_id, rel_product_id):
+    """
+    Deletes recommendation
+    This endpoint will delete one unique recommendation based on
+    the product id and related product id provided in the URI
+    """
+    app.logger.info("Request to delete a recommendation by product id and related product id")
+
+    find_result = Recommendation.find_by_id_relid(product_id, rel_product_id)
+
+    if not find_result.first():
+        return '', status.HTTP_204_NO_CONTENT
+
+    recommendation = find_result.first()
+    app.logger.info("Deleting recommendation with product id %s and related product id %s ...", 
+                    recommendation.id, recommendation.rel_id)
+    recommendation.delete()
+    app.logger.info("Deleted recommendation with product id %s and related product id %s ...", 
+                    recommendation.id, recommendation.rel_id)
+    
+    return '', status.HTTP_204_NO_CONTENT
+
+
+######################################################################
 # Error Handlers
 ######################################################################
 @app.errorhandler(DataValidationError)

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -143,6 +143,22 @@ class TestRecommendation(unittest.TestCase):
         returned_records = recommendation.find(recommendation.id).count()
         self.assertEqual(returned_records, 1, "Only one record should exist")
 
+    def test_find_by_id_relid(self):
+        """ Test find by id and rel_id function """
+        test_recommendation = self._create_one_recommendation(by_id=1, by_rel_id=2, by_type=1)
+        find_result = Recommendation.find_by_id_relid(by_id=test_recommendation.id,
+                                                      by_rel_id=test_recommendation.rel_id)
+        
+        self.assertEqual(len(find_result.all()), 1)
+        self.assertEqual(find_result.first(), test_recommendation)
+
+        find_result_empty = Recommendation.find_by_id_relid(by_id=test_recommendation.id,
+                                                            by_rel_id=3)
+        self.assertEqual(len(find_result_empty.all()), 0)
+
+        self.assertRaises(TypeError, Recommendation.find_by_id_relid, 1, "not_int")
+        self.assertRaises(TypeError, Recommendation.find_by_id_relid, "not_int", 1)
+
     def test_all(self):
         """ Test all class method """
         num_recs = 10

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -559,6 +559,30 @@ class TestRecommendationService(unittest.TestCase):
         else:
             self.assertEqual(resp.get_json()[2]["ids"][0], recommendation.rel_id, "Received incorrect records")
 
+    def test_delete_by_id_relid(self):
+        recommendations = self._create_recommendations(count=5)
+
+        recommendation = recommendations[0][0]
+
+        # delete a unique recommendation
+        resp = self.app.delete("/recommendations/{}/{}".format(recommendation.id, recommendation.rel_id))
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(resp.get_json())
+
+        # try querying that recommendation
+        resp = self.app.get("/recommendations/{}/{}".format(recommendation.id, recommendation.rel_id))
+
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+        # repeat the delete
+        resp = self.app.delete("/recommendations/{}/{}".format(recommendation.id, recommendation.rel_id))
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(resp.get_json())
+
+
+
     def test_internal_server_error(self):
         """ Test internal service error handler """
         message = "Test error message"


### PR DESCRIPTION
Added API so that we can call delete on `/recommendations/{product_id}/{rel_product_id}` to delete a unique recommendation.