### PR TITLE
Changed manifest.yml to use new dev space

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,12 +1,12 @@
 ---
 # This manifest deploys a Python Flask application with a Cloudant database
 applications:
-- name: nyu-recommendation-service-f20
+- name: nyu-recommendation-service-dev
   path: .
   instances: 2
   memory: 64M
   routes:
-  - route: nyu-recommendation-service-f20.us-south.cf.appdomain.cloud
+  - route: nyu-recommendation-service-dev.us-south.cf.appdomain.cloud
   disk_quota: 1024M
   buildpacks: 
   - python_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@
 applications:
 - name: nyu-recommendation-service-dev
   path: .
-  instances: 2
+  instances: 1
   memory: 64M
   routes:
   - route: nyu-recommendation-service-dev.us-south.cf.appdomain.cloud


### PR DESCRIPTION
- Since the application is now hosted on a new account and the name has been changed to `nyu-recommendation-service-dev`, I changed the settings (the app name and the route) in manifest to use the delivery pipeline. 
- The number of instances is also changed to 1, otherwise the test sometimes fails due to limit of connections.
- The delivery pipeline (build, test and deploy in dev space) should now be working automatically.