### PR TITLE
Search with only status

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -61,19 +61,19 @@ def get_all_recommendations():
             recommendations = Recommendation.find_by_id_relid(int(product_id), int(related_product_id))
         elif product_id:
             if type_id and by_status:
-                recommendations = Recommendation.find_by_id_type_status(int(product_id), int(type_id), (by_status=="true"))
+                recommendations = Recommendation.find_by_id_type_status(int(product_id), int(type_id), (by_status=="True"))
             elif type_id:
                 recommendations = Recommendation.find_by_id_type(int(product_id), int(type_id))
             elif by_status:
-                recommendations = Recommendation.find_by_id_status(int(product_id), (by_status=="true"))
+                recommendations = Recommendation.find_by_id_status(int(product_id), (by_status=="True"))
             else:
                 recommendations = Recommendation.find(int(product_id))
         elif type_id and by_status:
-            recommendations = Recommendation.find_by_type_id_status(int(type_id), (by_status=="true"))
+            recommendations = Recommendation.find_by_type_id_status(int(type_id), (by_status=="True"))
         elif type_id:
             recommendations = Recommendation.find_by_type_id(int(type_id))
         elif by_status:
-            recommendations = Recommendation.find_by_status((by_status=="true"))
+            recommendations = Recommendation.find_by_status((by_status=="True"))
         else:
             recommendations = Recommendation.all()
     except DataValidationError as error:
@@ -380,7 +380,12 @@ def update_recommendation(product_id, related_product_id):
         recommendation.deserialize(request.get_json())
 
         find = Recommendation.find_recommendation
-        old_recommendation = find(by_id=recommendation.product_id, by_rel_id=recommendation.related_product_id).first()
+        old_recommendation = find(by_id=recommendation.product_id, 
+                                  by_rel_id=recommendation.related_product_id, 
+                                  by_status=True).first() \
+                          or find(by_id=recommendation.product_id, 
+                                  by_rel_id=recommendation.related_product_id,
+                                  by_status=False).first()
     except DataValidationError as error:
         raise DataValidationError(error)
 

--- a/service/service.py
+++ b/service/service.py
@@ -61,19 +61,19 @@ def get_all_recommendations():
             recommendations = Recommendation.find_by_id_relid(int(product_id), int(related_product_id))
         elif product_id:
             if type_id and by_status:
-                recommendations = Recommendation.find_by_id_type_status(int(product_id), int(type_id), bool(by_status))
+                recommendations = Recommendation.find_by_id_type_status(int(product_id), int(type_id), (by_status=="true"))
             elif type_id:
                 recommendations = Recommendation.find_by_id_type(int(product_id), int(type_id))
             elif by_status:
-                recommendations = Recommendation.find_by_id_status(int(product_id), bool(by_status))
+                recommendations = Recommendation.find_by_id_status(int(product_id), (by_status=="true"))
             else:
                 recommendations = Recommendation.find(int(product_id))
         elif type_id and by_status:
-            recommendations = Recommendation.find_by_type_id_status(int(type_id), bool(by_status))
+            recommendations = Recommendation.find_by_type_id_status(int(type_id), (by_status=="true"))
         elif type_id:
             recommendations = Recommendation.find_by_type_id(int(type_id))
         elif by_status:
-            recommendations = Recommendation.find_by_status(bool(by_status))
+            recommendations = Recommendation.find_by_status((by_status=="true"))
         else:
             recommendations = Recommendation.all()
     except DataValidationError as error:

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -55,9 +55,9 @@
                 <label class="control-label col-sm-2" for="recommendation_status">Active Status:</label>
                 <div class="col-sm-10">
                   <select class="form-control" id="recommendation_status">
-                      <option value="true" selected>True</option>
-                      <option value="false">False</option>
-                      <option value="any">Any</option>
+                      <option value="True" selected>True</option>
+                      <option value="False">False</option>
+                      <option value="Any">Any</option>
                   </select>
                 </div>
               </div>

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -57,6 +57,7 @@
                   <select class="form-control" id="recommendation_status">
                       <option value="true" selected>True</option>
                       <option value="false">False</option>
+                      <option value="any">Any</option>
                   </select>
                 </div>
               </div>

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -57,7 +57,6 @@
                   <select class="form-control" id="recommendation_status">
                       <option value="True" selected>True</option>
                       <option value="False">False</option>
-                      <option value="Any">Any</option>
                   </select>
                 </div>
               </div>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -38,7 +38,7 @@ $(function () {
         var product_id = $("#recommendation_product_id").val();
         var related_product_id = $("#recommendation_related_product_id").val();
         var type_id = $("#recommendation_type_id").val();
-        var status = $("#recommendation_status").val() != "False";
+        var status = $("#recommendation_status").val() == "True";
 
         if (!type_id){
             type_id = "1";
@@ -83,7 +83,7 @@ $(function () {
         var product_id = $("#recommendation_product_id").val();
         var related_product_id = $("#recommendation_related_product_id").val();
         var type_id = $("#recommendation_type_id").val();
-        var status = $("#recommendation_status").val() != "False";
+        var status = $("#recommendation_status").val() == "True";
 
         if (!type_id){
             type_id = "1";
@@ -219,7 +219,7 @@ $(function () {
                 queryString += 'type-id=' + type_id
             }
         }
-        if (status && (status != "Any")) {
+        if (status) {
             if (queryString.length > 0) {
                 queryString += '&status=' + status
             } else {

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -219,7 +219,7 @@ $(function () {
                 queryString += 'type-id=' + type_id
             }
         }
-        if (status) {
+        if (status && (status != "any")) {
             if (queryString.length > 0) {
                 queryString += '&status=' + status
             } else {

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -190,7 +190,7 @@ $(function () {
     });
 
     // ****************************************
-    // Search for a Pet
+    // Search for a Recommendation
     // ****************************************
 
     $("#search-btn").click(function () {
@@ -198,7 +198,7 @@ $(function () {
         var product_id = $("#recommendation_product_id").val();
         var related_product_id = $("#recommendation_related_product_id").val();
         var type_id = $("#recommendation_type_id").val();
-        var status = $("#recommendation_status").val() == "true";
+        var status = $("#recommendation_status").val();
 
         var queryString = ""
 

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -10,9 +10,9 @@ $(function () {
         $("#recommendation_related_product_id").val(res["related-product-id"]);
         $("#recommendation_type_id").val(res["type-id"]);
         if (res["status"] == true) {
-            $("#recommendation_status").val("true");
+            $("#recommendation_status").val("True");
         } else {
-            $("#recommendation_status").val("false");
+            $("#recommendation_status").val("False");
         }
     }
 
@@ -38,7 +38,7 @@ $(function () {
         var product_id = $("#recommendation_product_id").val();
         var related_product_id = $("#recommendation_related_product_id").val();
         var type_id = $("#recommendation_type_id").val();
-        var status = $("#recommendation_status").val() == "true";
+        var status = $("#recommendation_status").val() != "False";
 
         if (!type_id){
             type_id = "1";
@@ -83,7 +83,7 @@ $(function () {
         var product_id = $("#recommendation_product_id").val();
         var related_product_id = $("#recommendation_related_product_id").val();
         var type_id = $("#recommendation_type_id").val();
-        var status = $("#recommendation_status").val() == "true";
+        var status = $("#recommendation_status").val() != "False";
 
         if (!type_id){
             type_id = "1";
@@ -219,7 +219,7 @@ $(function () {
                 queryString += 'type-id=' + type_id
             }
         }
-        if (status && (status != "any")) {
+        if (status && (status != "Any")) {
             if (queryString.length > 0) {
                 queryString += '&status=' + status
             } else {


### PR DESCRIPTION
The following changes were made to complete search with only status:

- In `rest_api.js`, I changed `var status` from boolean to string, so that when `status` is false the `queryString` can still include `status` as argument.
- In service.py I changed the way we use `by_status` obtained from the args.
- Added an option "Any" in the status selection, so we can search recommendations with no specified status.